### PR TITLE
chore: use `cp`, not `git mv` in update script

### DIFF
--- a/redhat/release/update-to-head.sh
+++ b/redhat/release/update-to-head.sh
@@ -61,8 +61,8 @@ if [[ -d redhat/patches ]] && [ "$(ls -A redhat/patches)" ]; then
   git apply redhat/patches/*
 fi
 
-git mv redhat/overlays/log_server/Dockerfile.logserver .
-git mv redhat/overlays/log_signer/Dockerfile.logsigner .
+cp redhat/overlays/log_server/Dockerfile.logserver .
+cp redhat/overlays/log_signer/Dockerfile.logsigner .
 
 git add . # Adds applied patches
 git add $custom_files # Adds custom files


### PR DESCRIPTION
The Dockerfiles live on a separate branch and `git` won't move the files because you can't `git mv` from one branch to another. So, just copy the files to root and add/commit them.