### PR TITLE
add `netcat` image to this repository

### DIFF
--- a/redhat/overlays/Dockerfile.netcat
+++ b/redhat/overlays/Dockerfile.netcat
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:9c810eccada0cc6f25b46eeeea4516bab01828faef4fdd2fe49c760518b90dd1
+
+RUN microdnf -y install nc


### PR DESCRIPTION
This allows the `netcat` dependency to be associated and built with `trillian` in RHTAP.