### PR TITLE
chore: update DOCKERFILE param for all pipelines to use local file

### DIFF
--- a/.tekton/trillian-database-pull-request.yaml
+++ b/.tekton/trillian-database-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/trillian/redhat-v1.5.2/Dockerfile.database
+    value: Dockerfile.database
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/trillian-database-push.yaml
+++ b/.tekton/trillian-database-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/trillian/redhat-v1.5.2/Dockerfile.database
+    value: Dockerfile.database
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image

--- a/.tekton/trillian-logserver-pull-request.yaml
+++ b/.tekton/trillian-logserver-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/trillian/redhat-v1.5.2/Dockerfile.logserver
+    value: Dockerfile.logserver
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/trillian-logserver-push.yaml
+++ b/.tekton/trillian-logserver-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/trillian/redhat-v1.5.2/Dockerfile.logserver
+    value: Dockerfile.logserver
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image

--- a/.tekton/trillian-logsigner-pull-request.yaml
+++ b/.tekton/trillian-logsigner-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/trillian/redhat-v1.5.2/Dockerfile.logsigner
+    value: Dockerfile.logsigner
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/trillian-logsigner-push.yaml
+++ b/.tekton/trillian-logsigner-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/trillian/redhat-v1.5.2/Dockerfile.logsigner
+    value: Dockerfile.logsigner
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image

--- a/.tekton/trillian-netcat-pull-request.yaml
+++ b/.tekton/trillian-netcat-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/trillian/redhat-v1.5.2/Dockerfile.netcat
+    value: Dockerfile.netcat
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/trillian-netcat-push.yaml
+++ b/.tekton/trillian-netcat-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/trillian/redhat-v1.5.2/Dockerfile.netcat
+    value: Dockerfile.netcat
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image


### PR DESCRIPTION
When these components were onboarded, the Dockerfile specified in the HTML form was a full URL pointing to the github repository. Since the dockerfile will always be local and is part of the source, it should point to the local file instead. This will also fix a failing check in the RH Enterprise Contract.