### PR TITLE
chore: update image refs for all Dockerfiles

### DIFF
--- a/redhat/overlays/Dockerfile.database
+++ b/redhat/overlays/Dockerfile.database
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel8/mariadb-103
+FROM registry.redhat.io/rhel9/mariadb-105@sha256:786c020bd520749b54dec5d2eef815b645466aef4aa0fea5bbb59601ea501632
 
 USER root
 

--- a/redhat/overlays/Dockerfile.logserver
+++ b/redhat/overlays/Dockerfile.logserver
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=false
@@ -16,7 +16,7 @@ RUN go build -v ./cmd/trillian_log_server
 
 
 # Multi-Stage production build
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as deploy
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b40f52aa68b29634ff45429ee804afbaa61b33de29ae775568933c71610f07a4 AS deploy
 
 # Retrieve the binary from the previous stage
 COPY --from=builder /opt/app-root/src/trillian_log_server /

--- a/redhat/overlays/Dockerfile.logsigner
+++ b/redhat/overlays/Dockerfile.logsigner
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=false

--- a/redhat/overlays/Dockerfile.logsigner
+++ b/redhat/overlays/Dockerfile.logsigner
@@ -16,7 +16,7 @@ RUN go build -v ./cmd/trillian_log_signer
 
 
 # Multi-Stage production build
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as deploy
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b40f52aa68b29634ff45429ee804afbaa61b33de29ae775568933c71610f07a4 AS deploy
 
 # Retrieve the binary from the previous stage
 COPY --from=builder /opt/app-root/src/trillian_log_signer /

--- a/redhat/overlays/Dockerfile.netcat
+++ b/redhat/overlays/Dockerfile.netcat
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:9c810eccada0cc6f25b46eeeea4516bab01828faef4fdd2fe49c760518b90dd1
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b40f52aa68b29634ff45429ee804afbaa61b33de29ae775568933c71610f07a4
 
 LABEL description="Netcat is a computer networking utility for reading from and writing to network connections using TCP or UDP."
 LABEL io.k8s.description="netcat is a computer networking utility for reading from and writing to network connections using TCP or UDP."


### PR DESCRIPTION
This commit updates the go-toolset base image SHA to the latest for UBI9. It also replaces go-toolset with ubi-minimal for the deploy images in logserver and logsigner.

/cherry-pick midstream-v1.5.2

/cc @tommyd450 