### PR TITLE
chore: punk prefetch-input

### DIFF
--- a/.tekton/trillian-netcat-pull-request.yaml
+++ b/.tekton/trillian-netcat-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{}'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -196,10 +198,10 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
-        operator: in
+      - input: $(params.prefetch-input)
+        operator: notin
         values:
-        - "true"
+        - ""
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/trillian-netcat-pull-request.yaml
+++ b/.tekton/trillian-netcat-pull-request.yaml
@@ -31,7 +31,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: prefetch-input
-    value: '{}'
+    value: ''
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -201,7 +201,7 @@ spec:
       - input: $(params.prefetch-input)
         operator: notin
         values:
-        - ""
+        - "{}"
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/trillian-netcat-push.yaml
+++ b/.tekton/trillian-netcat-push.yaml
@@ -27,6 +27,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{}'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -193,10 +195,10 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
-        operator: in
+      - input: $(params.prefetch-input)
+        operator: notin
         values:
-        - "true"
+        - ""
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/trillian-netcat-push.yaml
+++ b/.tekton/trillian-netcat-push.yaml
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: prefetch-input
-    value: '{}'
+    value: ''
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -198,7 +198,7 @@ spec:
       - input: $(params.prefetch-input)
         operator: notin
         values:
-        - ""
+        - "{}"
       workspaces:
       - name: source
         workspace: workspace


### PR DESCRIPTION
Running this task is required by the EC even if there are no dependencies to fetch.