### PR TITLE
chore: copy redhat overlays from redhat-v1.5.2

### DIFF
--- a/60-load-db.sh
+++ b/60-load-db.sh
@@ -1,0 +1,1 @@
+mysql $mysql_flags $MYSQL_DATABASE < /docker-entrypoint-initdb.d/storage.sql

--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -1,0 +1,16 @@
+FROM registry.redhat.io/rhel9/mariadb-105@sha256:786c020bd520749b54dec5d2eef815b645466aef4aa0fea5bbb59601ea501632
+
+USER root
+
+COPY examples/deployment/docker/db_server/mysql.cnf /etc/mysql/conf.d/trillian.cnf
+COPY storage/mysql/schema/storage.sql /docker-entrypoint-initdb.d/storage.sql
+COPY 60-load-db.sh /usr/share/container-scripts/mysql/init/60-load-db.sh
+RUN chmod -R 775 /docker-entrypoint-initdb.d && \
+    chmod 644 /etc/mysql/conf.d/trillian.cnf && \
+    chmod 775 /usr/share/container-scripts/mysql/init/60-load-db.sh
+USER 1001
+LABEL description="MariaDB is a community-developed, commercially supported fork of the MySQL relational database management system"
+LABEL io.k8s.description="MariaDB is a community-developed, commercially supported fork of the MySQL relational database management system"
+LABEL io.k8s.display-name="trillian_db"
+LABEL io.openshift.tags="trillian database trusted-signer"
+LABEL summary="Provides the backing database for running trillian"

--- a/Dockerfile.logserver
+++ b/Dockerfile.logserver
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS builder
+ENV APP_ROOT=/opt/app-root
+ENV GOPATH=$APP_ROOT
+ENV CGO_ENABLED=false
+ENV -buildvcs=false
+
+WORKDIR $APP_ROOT/src/
+ADD go.mod go.sum $APP_ROOT/src/
+RUN go mod download
+RUN git config --global --add safe.directory /opt/app-root/src
+
+# Add source code
+ADD ./ $APP_ROOT/src/
+
+RUN go build -v ./cmd/trillian_log_server
+
+
+# Multi-Stage production build
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b40f52aa68b29634ff45429ee804afbaa61b33de29ae775568933c71610f07a4 AS deploy
+
+# Retrieve the binary from the previous stage
+COPY --from=builder /opt/app-root/src/trillian_log_server /
+
+LABEL description="Trillian is an implementation of the concepts described in the Verifiable Data Structures white paper, which in turn is an extension and generalisation of the ideas which underpin Certificate Transparency."
+LABEL io.k8s.description="Trillian is an implementation of the concepts described in the Verifiable Data Structures white paper."
+LABEL io.k8s.display-name="trillian_log_server"
+LABEL io.openshift.tags="trillian-logserver trusted-signer"
+LABEL summary="Provides the trillian logserver binary for running trillian logserver"
+
+# Set the binary as the entrypoint of the container
+ENTRYPOINT ["/trillian_log_server"]

--- a/Dockerfile.logsigner
+++ b/Dockerfile.logsigner
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS builder
+ENV APP_ROOT=/opt/app-root
+ENV GOPATH=$APP_ROOT
+ENV CGO_ENABLED=false
+ENV -buildvcs=false
+
+WORKDIR $APP_ROOT/src/
+ADD go.mod go.sum $APP_ROOT/src/
+RUN go mod download
+RUN git config --global --add safe.directory /opt/app-root/src
+
+# Add source code
+ADD ./ $APP_ROOT/src/
+
+RUN go build -v ./cmd/trillian_log_signer
+
+
+# Multi-Stage production build
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b40f52aa68b29634ff45429ee804afbaa61b33de29ae775568933c71610f07a4 AS deploy
+
+# Retrieve the binary from the previous stage
+COPY --from=builder /opt/app-root/src/trillian_log_signer /
+
+LABEL description="Trillian is an implementation of the concepts described in the Verifiable Data Structures white paper, which in turn is an extension and generalisation of the ideas which underpin Certificate Transparency."
+LABEL io.k8s.description="Trillian is an implementation of the concepts described in the Verifiable Data Structures white paper."
+LABEL io.k8s.display-name="trillian_log_signer"
+LABEL io.openshift.tags="trillian-logsigner trusted-signer"
+LABEL summary="Provides the trillian logsigner binary for running trillian logsigner"
+
+# Set the binary as the entrypoint of the container
+ENTRYPOINT ["/trillian_log_signer"]

--- a/Dockerfile.netcat
+++ b/Dockerfile.netcat
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b40f52aa68b29634ff45429ee804afbaa61b33de29ae775568933c71610f07a4
+
+LABEL description="Netcat is a computer networking utility for reading from and writing to network connections using TCP or UDP."
+LABEL io.k8s.description="netcat is a computer networking utility for reading from and writing to network connections using TCP or UDP."
+LABEL io.k8s.display-name="trillian_netcat"
+LABEL io.openshift.tags="trillian netcat trusted-signer"
+LABEL summary="Provides the trillian netcat binary for running trillian netcat"
+
+RUN microdnf -y install nc


### PR DESCRIPTION
Adds all of the existing overlays from the `redhat-v1.5.2` branch to this new release branch