### PR TITLE
chore: remove hermetic build from netcat

### DIFF
--- a/.tekton/trillian-netcat-1-5-pull-request.yaml
+++ b/.tekton/trillian-netcat-1-5-pull-request.yaml
@@ -203,10 +203,10 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
-        operator: in
+      - input: $(params.prefetch-input)
+        operator: notin
         values:
-        - "true"
+        - "false"
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/trillian-netcat-1-5-pull-request.yaml
+++ b/.tekton/trillian-netcat-1-5-pull-request.yaml
@@ -33,8 +33,6 @@ spec:
     value: true
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
-  - name: hermetic
-    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/trillian-netcat-1-5-push.yaml
+++ b/.tekton/trillian-netcat-1-5-push.yaml
@@ -200,10 +200,10 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
-        operator: in
+      - input: $(params.prefetch-input)
+        operator: notin
         values:
-        - "true"
+        - "false"
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/trillian-netcat-1-5-push.yaml
+++ b/.tekton/trillian-netcat-1-5-push.yaml
@@ -30,8 +30,6 @@ spec:
     value: true
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
-  - name: hermetic
-    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
We can't do hermetic builds with a `microdnf install` in the Dockerfile. The Konflux team is working towards making this possible, but as of TP2 it will not be available.