### PR TITLE
fix-konflux-ec

### DIFF
--- a/Dockerfile.database.rh
+++ b/Dockerfile.database.rh
@@ -9,8 +9,11 @@ RUN chmod -R 775 /docker-entrypoint-initdb.d && \
     chmod 644 /etc/mysql/conf.d/trillian.cnf && \
     chmod 775 /usr/share/container-scripts/mysql/init/60-load-db.sh
 USER 1001
+
 LABEL description="MariaDB is a community-developed, commercially supported fork of the MySQL relational database management system"
 LABEL io.k8s.description="MariaDB is a community-developed, commercially supported fork of the MySQL relational database management system"
 LABEL io.k8s.display-name="trillian_db"
 LABEL io.openshift.tags="trillian database trusted-signer"
 LABEL summary="Provides the backing database for running trillian"
+LABEL com.redhat.component="trillian_db"
+LABEL name="trillian_db"

--- a/Dockerfile.logserver.rh
+++ b/Dockerfile.logserver.rh
@@ -14,7 +14,6 @@ ADD ./ $APP_ROOT/src/
 
 RUN go build -v ./cmd/trillian_log_server
 
-
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:119ac25920c8bb50c8b5fd75dcbca369bf7d1f702b82f3d39663307890f0bf26 AS deploy
 
@@ -26,6 +25,8 @@ LABEL io.k8s.description="Trillian is an implementation of the concepts describe
 LABEL io.k8s.display-name="trillian_log_server"
 LABEL io.openshift.tags="trillian-logserver trusted-signer"
 LABEL summary="Provides the trillian logserver binary for running trillian logserver"
+LABEL com.redhat.component="trillian_log_server"
+LABEL name="trillian_log_server"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["/trillian_log_server"]

--- a/Dockerfile.logsigner.rh
+++ b/Dockerfile.logsigner.rh
@@ -25,6 +25,8 @@ LABEL io.k8s.description="Trillian is an implementation of the concepts describe
 LABEL io.k8s.display-name="trillian_log_signer"
 LABEL io.openshift.tags="trillian-logsigner trusted-signer"
 LABEL summary="Provides the trillian logsigner binary for running trillian logsigner"
+LABEL com.redhat.component="trillian_log_signer"
+LABEL name="trillian_log_signer"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["/trillian_log_signer"]

--- a/Dockerfile.redis.rh
+++ b/Dockerfile.redis.rh
@@ -6,9 +6,10 @@ LABEL io.k8s.display-name="redis container image for Red Hat trusted artifact si
 LABEL io.openshift.tags="redis, Red Hat trusted artifact signer."
 LABEL summary="Runs redis in appendonly mode with enablement for external connections by default."
 LABEL com.redhat.component="redis"
+LABEL name="redis"
 
 USER 1001
-#
+
 RUN sed -i 's/#bind 127.0.0.1 -::1/bind 0.0.0.0/g' /etc/redis/redis.conf && sed -i 's/appendonly no/appendonly yes/g' /etc/redis/redis.conf
 
 ENTRYPOINT ["container-entrypoint"]


### PR DESCRIPTION
Seems like konflux needs new labels for the images: https://console.redhat.com/preview/application-pipeline/workspaces/rhtas/applications/trillian/pipelineruns/trillian-k7bmf-x9fg7/security