### PR TITLE
chore: update deprecated-image-check task

### DIFF
--- a/.tekton/database-pull-request.yaml
+++ b/.tekton/database-pull-request.yaml
@@ -274,6 +274,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/database-pull-request.yaml
+++ b/.tekton/database-pull-request.yaml
@@ -282,10 +282,6 @@ spec:
           value: deprecated-image-check
         - name: bundle
           value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4@sha256:6b1b325de0af29b6e9a0696f4d2b669a1e6a046941726cc97c5e42785aad870c
-        - name: IMAGE_URL
-          value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4
-        - name: IMAGE_DIGEST
-          value: 6b1b325de0af29b6e9a0696f4d2b669a1e6a046941726cc97c5e42785aad870c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/database-pull-request.yaml
+++ b/.tekton/database-pull-request.yaml
@@ -282,6 +282,10 @@ spec:
           value: deprecated-image-check
         - name: bundle
           value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4@sha256:6b1b325de0af29b6e9a0696f4d2b669a1e6a046941726cc97c5e42785aad870c
+        - name: IMAGE_URL
+          value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4
+        - name: IMAGE_DIGEST
+          value: 6b1b325de0af29b6e9a0696f4d2b669a1e6a046941726cc97c5e42785aad870c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/database-push.yaml
+++ b/.tekton/database-push.yaml
@@ -271,6 +271,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/database-push.yaml
+++ b/.tekton/database-push.yaml
@@ -279,6 +279,10 @@ spec:
           value: deprecated-image-check
         - name: bundle
           value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4@sha256:6b1b325de0af29b6e9a0696f4d2b669a1e6a046941726cc97c5e42785aad870c
+        - name: IMAGE_URL
+          value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4
+        - name: IMAGE_DIGEST
+          value: 6b1b325de0af29b6e9a0696f4d2b669a1e6a046941726cc97c5e42785aad870c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/database-push.yaml
+++ b/.tekton/database-push.yaml
@@ -279,10 +279,6 @@ spec:
           value: deprecated-image-check
         - name: bundle
           value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4@sha256:6b1b325de0af29b6e9a0696f4d2b669a1e6a046941726cc97c5e42785aad870c
-        - name: IMAGE_URL
-          value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4
-        - name: IMAGE_DIGEST
-          value: 6b1b325de0af29b6e9a0696f4d2b669a1e6a046941726cc97c5e42785aad870c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/logserver-pull-request.yaml
+++ b/.tekton/logserver-pull-request.yaml
@@ -274,6 +274,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/logserver-push.yaml
+++ b/.tekton/logserver-push.yaml
@@ -271,6 +271,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/logsigner-pull-request.yaml
+++ b/.tekton/logsigner-pull-request.yaml
@@ -274,6 +274,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/logsigner-push.yaml
+++ b/.tekton/logsigner-push.yaml
@@ -271,6 +271,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/redis-pull-request.yaml
+++ b/.tekton/redis-pull-request.yaml
@@ -271,6 +271,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/redis-push.yaml
+++ b/.tekton/redis-push.yaml
@@ -268,6 +268,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:


### PR DESCRIPTION
The task params have changed and now require IMAGE_URL and IMAGE_DIGEST. It is not clear if the `bundle` param should be removed. I suspect it should be, but leaving it for the moment.

~DO NOT MERGE YET~