### PR TITLE
switch-to-rhel-8

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -14,7 +14,7 @@ jobs:
         branch: [main]
     with:
       branch: ${{ matrix.branch }}
-      images: '["registry.access.redhat.com/ubi9/go-toolset", "registry.access.redhat.com/ubi9/ubi-minimal", "registry.redhat.io/rhel9/mariadb-105", "registry.redhat.io/rhel9/redis-6"]'
+      images: '["registry.access.redhat.com/ubi9/go-toolset", "registry.access.redhat.com/ubi9/ubi-minimal", "registry.redhat.io/rhel8/mariadb-105", "registry.redhat.io/rhel8/redis-6"]'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       registry_redhat_io_username: ${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}

--- a/Dockerfile.database.rh
+++ b/Dockerfile.database.rh
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9/mariadb-105@sha256:cc5c1a07859ad985445ce12489b3d8ac05c114bdfc1a2a94a93db684afe8967f
+FROM registry.redhat.io/rhel8/mariadb-105@sha256:7f01843a399a5abd2898eaaf8777948dbb34a773b679b143b06d5dc7d86b7f47
 
 USER root
 

--- a/Dockerfile.redis.rh
+++ b/Dockerfile.redis.rh
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9/redis-6@sha256:1377ad49a53aeb409ace62b876923e8ba9e69300257db40883869ab1aa1560e3
+FROM registry.redhat.io/rhel8/redis-6@sha256:32fb43463e99a5cae3c88f4a0ef06518bbc6bfa7a50d58bc3d0d1b09e16ad8d0
 
 LABEL description="Securesign redis is built ontop of rhel9/redis-6 but accepts external connections and runs appendonly mode with full durability."
 LABEL io.k8s.description="Securesign redis is built ontop of rhel9/redis-6 but accepts external connections and runs appendonly mode with full durability."
@@ -8,9 +8,11 @@ LABEL summary="Runs redis in appendonly mode with enablement for external connec
 LABEL com.redhat.component="redis"
 LABEL name="redis"
 
-USER 1001
+USER root
 
-RUN sed -i 's/#bind 127.0.0.1 -::1/bind 0.0.0.0/g' /etc/redis/redis.conf && sed -i 's/appendonly no/appendonly yes/g' /etc/redis/redis.conf
+RUN sed -i 's/#bind 127.0.0.1 -::1/bind 0.0.0.0/g' /etc/redis.conf && sed -i 's/appendonly no/appendonly yes/g' /etc/redis.conf
+
+USER 1001
 
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-redis"]


### PR DESCRIPTION
@lance @kahboom The go tool set vulnerabilities seem to be fixed, I am still seeing some vulnerabilities pop up for maria db and redis, this should solve this by downgrading to the rhel8 version which seems to be Ok.