### PR TITLE
[SECURESIGN-1049] Changing url to securesign namespace

### DIFF
--- a/.tekton/database-pull-request.yaml
+++ b/.tekton/database-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/database:on-pr-{{revision}}
+    value: quay.io/securesign/trillian-database:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/database-push.yaml
+++ b/.tekton/database-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/database:{{revision}}
+    value: quay.io/securesign/trillian-database:{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/logserver-pull-request.yaml
+++ b/.tekton/logserver-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/logserver:on-pr-{{revision}}
+    value: quay.io/securesign/trillian-logserver:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/logserver-push.yaml
+++ b/.tekton/logserver-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/logserver:{{revision}}
+    value: quay.io/securesign/trillian-logserver:{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/logsigner-pull-request.yaml
+++ b/.tekton/logsigner-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/logsigner:on-pr-{{revision}}
+    value: quay.io/securesign/trillian-logsigner:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/logsigner-push.yaml
+++ b/.tekton/logsigner-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/logsigner:{{revision}}
+    value: quay.io/securesign/trillian-logsigner:{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/redis-pull-request.yaml
+++ b/.tekton/redis-pull-request.yaml
@@ -25,7 +25,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/redis:on-pr-{{revision}}
+    value: quay.io/securesign/trillian-redis:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/redis-push.yaml
+++ b/.tekton/redis-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/redis:{{revision}}
+    value: quay.io/securesign/trillian-redis:{{revision}}
   - name: path-context
     value: .
   - name: revision


### PR DESCRIPTION
Pointing where we push our images to our securesign namespace rather than the default rhtas-tenant one.