### PR TITLE
chore: move CLIs to securesign org on quay.io

### DIFF
--- a/.tekton/createtree-pull-request.yaml
+++ b/.tekton/createtree-pull-request.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/createtree:on-pr-{{revision}}
+    value: quay.io/securesign/trillian-createtree:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/createtree-push.yaml
+++ b/.tekton/createtree-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/createtree:{{revision}}
+    value: quay.io/securesign/trillian-createtree:{{revision}}
   - name: dockerfile
     value: Dockerfile.createtree.rh
   - name: build-source-image

--- a/.tekton/updatetree-pull-request.yaml
+++ b/.tekton/updatetree-pull-request.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/updatetree:on-pr-{{revision}}
+    value: quay.io/securesign/trillian-updatetree:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/updatetree-push.yaml
+++ b/.tekton/updatetree-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtas-tenant/trillian/updatetree:{{revision}}
+    value: quay.io/securesign/trillian-updatetree:{{revision}}
   - name: dockerfile
     value: Dockerfile.updatetree.rh
   - name: build-source-image


### PR DESCRIPTION
The images produced for the createtree and updatetree CLI binaries should be pushed to the securesign org on quay.io
