### PR TITLE
chore: SECURESIGN-1245 multi-arch builds

### DIFF
--- a/Build-clis.mak
+++ b/Build-clis.mak
@@ -1,0 +1,61 @@
+.PHONY:
+createtree-cross-platform: createtree-darwin-arm64 createtree-darwin-amd64 createtree-linux-amd64 createtree-linux-arm64 createtree-linux-ppc64le createtree-linux-s390x createtree-windows-amd64 ## Build all distributable (cross-platform) binaries
+
+.PHONY:
+updatetree-cross-platform: updatetree-darwin-arm64 updatetree-darwin-amd64 updatetree-linux-amd64 updatetree-linux-arm64 updatetree-linux-ppc64le updatetree-linux-s390x updatetree-windows-amd64 ## Build all distributable (cross-platform) binaries
+
+.PHONY:	createtree-darwin-arm64
+createtree-darwin-arm64: ## Build for mac M1
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -v -o createtree-darwin-arm64 -trimpath ./cmd/createtree
+
+.PHONY: createtree-darwin-amd64
+createtree-darwin-amd64:  ## Build for Darwin (macOS)
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -v -o createtree-darwin-amd64 -trimpath ./cmd/createtree
+
+.PHONY: createtree-linux-amd64
+createtree-linux-amd64: ## Build for Linux amd64
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o createtree-linux-amd64 -trimpath ./cmd/createtree
+
+.PHONY: createtree-linux-arm64
+createtree-linux-arm64: ## Build for Linux arm64
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -v -o createtree-linux-arm64 -trimpath ./cmd/createtree
+
+.PHONY: createtree-linux-ppc64le
+createtree-linux-ppc64le: ## Build for Linux ppc64le
+	env CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -v -o createtree-linux-ppc64le -trimpath ./cmd/createtree
+
+.PHONY: createtree-linux-s390x
+createtree-linux-s390x:  ## Build for Linux s390x
+	env CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -v -o createtree-linux-s390x -trimpath ./cmd/createtree
+
+.PHONY: createtree-windows-amd64
+createtree-windows-amd64: ## Build for Windows
+	env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -v -o createtree-windows-amd64.exe -trimpath ./cmd/createtree
+
+.PHONY:	updatetree-darwin-arm64
+updatetree-darwin-arm64: ## Build for mac M1
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -v -o updatetree-darwin-arm64 -trimpath ./cmd/updatetree
+
+.PHONY: updatetree-darwin-amd64
+updatetree-darwin-amd64:  ## Build for Darwin (macOS)
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -v -o updatetree-darwin-amd64 -trimpath ./cmd/updatetree
+
+.PHONY: updatetree-linux-amd64
+updatetree-linux-amd64: ## Build for Linux amd64
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o updatetree-linux-amd64 -trimpath ./cmd/updatetree
+
+.PHONY: updatetree-linux-arm64
+updatetree-linux-arm64: ## Build for Linux arm64
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -v -o updatetree-linux-arm64 -trimpath ./cmd/updatetree
+
+.PHONY: updatetree-linux-ppc64le
+updatetree-linux-ppc64le: ## Build for Linux ppc64le
+	env CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -v -o updatetree-linux-ppc64le -trimpath ./cmd/updatetree
+
+.PHONY: updatetree-linux-s390x
+updatetree-linux-s390x:  ## Build for Linux s390x
+	env CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -v -o updatetree-linux-s390x -trimpath ./cmd/updatetree
+
+.PHONY: updatetree-windows-amd64
+updatetree-windows-amd64: ## Build for Windows
+	env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -v -o updatetree-windows-amd64.exe -trimpath ./cmd/updatetree

--- a/Dockerfile.createtree.rh
+++ b/Dockerfile.createtree.rh
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:5049a9d9be3914049aa983b66c695047d87c248f5fc95a222a63a15578a376bc AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:5049a9d9be3914049aa983b66c695047d87c248f5fc95a222a63a15578a376bc AS build-env
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=false
@@ -6,19 +6,26 @@ ENV -buildvcs=false
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/
-RUN go mod download
-RUN git config --global --add safe.directory /opt/app-root/src
-
 # Add source code
 ADD ./ $APP_ROOT/src/
 
-RUN go build -v ./cmd/createtree
+RUN go mod download && \
+    git config --global --add safe.directory /opt/app-root/src && \
+    make -f Build-clis.mak createtree-cross-platform && \
+    cp createtree-linux-amd64 createtree && \
+    gzip createtree-linux-amd64 && \
+    gzip createtree-linux-ppc64le && \
+    gzip createtree-linux-s390x && \
+    gzip createtree-linux-arm64 && \
+    gzip createtree-darwin-amd64 && \
+    gzip createtree-darwin-arm64 && \
+    gzip createtree-windows-amd64.exe
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:73f7dcacb460dad137a58f24668470a5a2e47378838a0190eef0ab532c6e8998 AS deploy
 
 # Retrieve the binary from the previous stage
-COPY --from=builder /opt/app-root/src/createtree /
+COPY --from=build-env /opt/app-root/src/createtree /
 
 # Add license file
 COPY LICENSE /licenses/LICENSE
@@ -30,6 +37,31 @@ LABEL io.openshift.tags="trillian createtree trusted-artifact-signer"
 LABEL summary="Provides the trillian createtree binary for creating merkel trees."
 LABEL com.redhat.component="createtree"
 LABEL name="createtree"
+
+COPY --from=build-env /opt/app-root/src/createtree-darwin-amd64.gz /usr/local/bin/createtree-darwin-amd64.gz
+COPY --from=build-env /opt/app-root/src/createtree-windows-amd64.exe.gz /usr/local/bin/createtree-windows-amd64.exe.gz
+COPY --from=build-env /opt/app-root/src/createtree-darwin-arm64.gz /usr/local/bin/createtree-darwin-arm64.gz
+COPY --from=build-env /opt/app-root/src/createtree-linux-arm64.gz /usr/local/bin/createtree-linux-arm64.gz
+COPY --from=build-env /opt/app-root/src/createtree-linux-ppc64le.gz /usr/local/bin/createtree-linux-ppc64le.gz
+COPY --from=build-env /opt/app-root/src/createtree-linux-s390x.gz /usr/local/bin/createtree-linux-s390x.gz
+COPY --from=build-env /opt/app-root/src/createtree-linux-amd64.gz /usr/local/bin/createtree-linux-amd64.gz
+COPY --from=build-env /opt/app-root/src/createtree /usr/local/bin/createtree
+
+RUN chown root:0 /usr/local/bin/createtree && \
+    chmod g+wx /usr/local/bin/createtree && \
+    chown root:0 /usr/local/bin/createtree-darwin-amd64.gz && chmod g+wx /usr/local/bin/createtree-darwin-amd64.gz && \
+    chown root:0 /usr/local/bin/createtree-darwin-arm64.gz && chmod g+wx /usr/local/bin/createtree-darwin-arm64.gz && \
+    chown root:0 /usr/local/bin/createtree-windows-amd64.exe.gz && chmod g+wx /usr/local/bin/createtree-windows-amd64.exe.gz && \
+    chown root:0 /usr/local/bin/createtree-linux-arm64.gz && chmod g+wx /usr/local/bin/createtree-linux-arm64.gz && \
+    chown root:0 /usr/local/bin/createtree-linux-amd64.gz && chmod g+wx /usr/local/bin/createtree-linux-amd64.gz && \
+    chown root:0 /usr/local/bin/createtree-linux-ppc64le.gz && chmod g+wx /usr/local/bin/createtree-linux-ppc64le.gz && \
+    chown root:0 /usr/local/bin/createtree-linux-s390x.gz && chmod g+wx /usr/local/bin/createtree-linux-s390x.gz
+
+##Configure home directory
+ENV HOME=/home
+RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+
+WORKDIR ${HOME}
 
 # Do not run as root
 USER 1001

--- a/Dockerfile.updatetree.rh
+++ b/Dockerfile.updatetree.rh
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:5049a9d9be3914049aa983b66c695047d87c248f5fc95a222a63a15578a376bc AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:5049a9d9be3914049aa983b66c695047d87c248f5fc95a222a63a15578a376bc AS build-env
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=false
@@ -6,19 +6,27 @@ ENV -buildvcs=false
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/
-RUN go mod download
-RUN git config --global --add safe.directory /opt/app-root/src
-
 # Add source code
 ADD ./ $APP_ROOT/src/
 
-RUN go build -v ./cmd/updatetree
+RUN go mod download && \
+    git config --global --add safe.directory /opt/app-root/src && \
+    make -f Build-clis.mak updatetree-cross-platform && \
+    cp updatetree-linux-amd64 updatetree && \
+    gzip updatetree-linux-amd64 && \
+    gzip updatetree-linux-ppc64le && \
+    gzip updatetree-linux-s390x && \
+    gzip updatetree-linux-arm64 && \
+    gzip updatetree-darwin-amd64 && \
+    gzip updatetree-darwin-arm64 && \
+    gzip updatetree-windows-amd64.exe
+
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:73f7dcacb460dad137a58f24668470a5a2e47378838a0190eef0ab532c6e8998 AS deploy
 
 # Retrieve the binary from the previous stage
-COPY --from=builder /opt/app-root/src/updatetree /
+COPY --from=build-env /opt/app-root/src/updatetree /
 
 # Add license file
 COPY LICENSE /licenses/LICENSE
@@ -30,6 +38,31 @@ LABEL io.openshift.tags="trillian updatetree trusted-artifact-signer"
 LABEL summary="Provides the trillian updatetree binary for updating merkel trees."
 LABEL com.redhat.component="updatetree"
 LABEL name="updatetree"
+
+COPY --from=build-env /opt/app-root/src/updatetree-darwin-amd64.gz /usr/local/bin/updatetree-darwin-amd64.gz
+COPY --from=build-env /opt/app-root/src/updatetree-windows-amd64.exe.gz /usr/local/bin/updatetree-windows-amd64.exe.gz
+COPY --from=build-env /opt/app-root/src/updatetree-darwin-arm64.gz /usr/local/bin/updatetree-darwin-arm64.gz
+COPY --from=build-env /opt/app-root/src/updatetree-linux-arm64.gz /usr/local/bin/updatetree-linux-arm64.gz
+COPY --from=build-env /opt/app-root/src/updatetree-linux-ppc64le.gz /usr/local/bin/updatetree-linux-ppc64le.gz
+COPY --from=build-env /opt/app-root/src/updatetree-linux-s390x.gz /usr/local/bin/updatetree-linux-s390x.gz
+COPY --from=build-env /opt/app-root/src/updatetree-linux-amd64.gz /usr/local/bin/updatetree-linux-amd64.gz
+COPY --from=build-env /opt/app-root/src/updatetree /usr/local/bin/updatetree
+
+RUN chown root:0 /usr/local/bin/updatetree && \
+    chmod g+wx /usr/local/bin/updatetree && \
+    chown root:0 /usr/local/bin/updatetree-darwin-amd64.gz && chmod g+wx /usr/local/bin/updatetree-darwin-amd64.gz && \
+    chown root:0 /usr/local/bin/updatetree-darwin-arm64.gz && chmod g+wx /usr/local/bin/updatetree-darwin-arm64.gz && \
+    chown root:0 /usr/local/bin/updatetree-windows-amd64.exe.gz && chmod g+wx /usr/local/bin/updatetree-windows-amd64.exe.gz && \
+    chown root:0 /usr/local/bin/updatetree-linux-arm64.gz && chmod g+wx /usr/local/bin/updatetree-linux-arm64.gz && \
+    chown root:0 /usr/local/bin/updatetree-linux-amd64.gz && chmod g+wx /usr/local/bin/updatetree-linux-amd64.gz && \
+    chown root:0 /usr/local/bin/updatetree-linux-ppc64le.gz && chmod g+wx /usr/local/bin/updatetree-linux-ppc64le.gz && \
+    chown root:0 /usr/local/bin/updatetree-linux-s390x.gz && chmod g+wx /usr/local/bin/updatetree-linux-s390x.gz
+
+##Configure home directory
+ENV HOME=/home
+RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+
+WORKDIR ${HOME}
 
 # Do not run as root
 USER 1001


### PR DESCRIPTION
Modifies the image builds for `createtree` and `updatetree` to produce binaries for multiple architectures.
