### PR TITLE
Add MySQL TLS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+* Add TLS support for MySQL: https://github.com/google/trillian/pull/3593
+  * `--mysql_tls_ca`: users can provide a CA certificate, that is used to establish a secure communication with MySQL server. 
+  * `--mysql_server_name`: users can provide the name of the MySQL server to be used as the Server Name in the TLS configuration.
+
 ## Notable Changes
 
 * Updated go version 1.20 -> 1.21


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

This PR adds TLS support for MySQL connections in the Trillian server/signer. The key changes include:
- Added new flags:
  - `mysql_tls_ca`: Path to the CA certificate file for the MySQL TLS connection.
  - `mysql_server_name`: Name of the MySQL server to be used as the Server Name in the TLS configuration.

- TLS Configuration Registration:
  - Added a new function `registerTLSConfig()` to handle the registration of the custom TLS configuration.

_If no TLS configuration is provided, the connection defaults to non-TLS, ensuring backward compatibility._

Issue: https://github.com/google/trillian/issues/3592
### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).
