### PR TITLE
Ensure leader resignation on shutdown (#3790)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD
 
 * Bump golangci-lint to v2.1.6
+* Fix leader resignation during a graceful shutdown by @osmman in https://github.com/google/trillian/pull/3790
 
 ## v1.7.2
 

--- a/util/election/runner.go
+++ b/util/election/runner.go
@@ -108,8 +108,10 @@ func (er *Runner) Run(ctx context.Context, pending chan<- Resignation) {
 
 	klog.V(1).Infof("%s: start election-monitoring loop ", er.id)
 	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), time.Second)
+		defer closeCancel()
 		klog.Infof("%s: shutdown election-monitoring loop", er.id)
-		if err := er.election.Close(ctx); err != nil {
+		if err := er.election.Close(closeCtx); err != nil {
 			klog.Warningf("%s: election.Close: %v", er.id, err)
 		}
 	}()


### PR DESCRIPTION
To ensure proper leadership resignation during shutdown, an independent context is created for election.Close, preventing failure due to the canceled parent context.

Cherry-pick of https://github.com/google/trillian/pull/3790
