### PR TITLE
feat(fips): Upgrade Go to 1.24 and enable strict FIPS compliance

### DIFF
--- a/Dockerfile.createtree.rh
+++ b/Dockerfile.createtree.rh
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS build-env
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=1

--- a/Dockerfile.createtree.rh
+++ b/Dockerfile.createtree.rh
@@ -1,8 +1,9 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
-ENV CGO_ENABLED=false
+ENV CGO_ENABLED=1
 ENV -buildvcs=false
+ENV GOEXPERIMENT=strictfipsruntime
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/

--- a/Dockerfile.logserver.rh
+++ b/Dockerfile.logserver.rh
@@ -1,8 +1,9 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 as builder AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
-ENV CGO_ENABLED=false
+ENV CGO_ENABLED=1
 ENV -buildvcs=false
+ENV GOEXPERIMENT=strictfipsruntime
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/

--- a/Dockerfile.logserver.rh
+++ b/Dockerfile.logserver.rh
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 as builder AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=1

--- a/Dockerfile.logsigner.rh
+++ b/Dockerfile.logsigner.rh
@@ -1,8 +1,9 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 as builder AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
-ENV CGO_ENABLED=false
+ENV CGO_ENABLED=1
 ENV -buildvcs=false
+ENV GOEXPERIMENT=strictfipsruntime
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/

--- a/Dockerfile.logsigner.rh
+++ b/Dockerfile.logsigner.rh
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 as builder AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=1

--- a/Dockerfile.updatetree.rh
+++ b/Dockerfile.updatetree.rh
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS build-env
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=1

--- a/Dockerfile.updatetree.rh
+++ b/Dockerfile.updatetree.rh
@@ -1,8 +1,9 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
-ENV CGO_ENABLED=false
+ENV CGO_ENABLED=1
 ENV -buildvcs=false
+ENV GOEXPERIMENT=strictfipsruntime
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).

## Summary by Sourcery

Bump Go version to 1.24 and enable FIPS compliance in logserver and logsigner Docker builds

Enhancements:
- Update Dockerfiles to use Go 1.24
- Switch base images to FIPS-enabled variants for logserver and logsigner