### PR TITLE
[IGNORE][TEST] restrict request size

### DIFF
--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -76,6 +76,7 @@ var (
 	// Profiling related flags.
 	cpuProfile = flag.String("cpuprofile", "", "If set, write CPU profile to this file")
 	memProfile = flag.String("memprofile", "", "If set, write memory profile to this file")
+	maxMsgSize = flag.Int("max_msg_size_bytes", 1024*1024, "Max gRPC message size in bytes")
 )
 
 func main() {
@@ -106,6 +107,7 @@ func main() {
 		// Enable the server request counter tracing etc.
 		options = append(options, opts...)
 	}
+	options = append(options, grpc.MaxRecvMsgSize(*maxMsgSize))
 
 	sp, err := storage.NewProvider(*storageSystem, mf)
 	if err != nil {

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -76,7 +76,7 @@ var (
 	// Profiling related flags.
 	cpuProfile = flag.String("cpuprofile", "", "If set, write CPU profile to this file")
 	memProfile = flag.String("memprofile", "", "If set, write memory profile to this file")
-	maxMsgSize = flag.Int("max_msg_size_bytes", 1024*1024, "Max gRPC message size in bytes")
+	maxMsgSize = flag.Int("max_msg_size_bytes", 4024*1024, "Max gRPC message size in bytes")
 )
 
 func main() {

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -84,6 +84,7 @@ var (
 	// Profiling related flags.
 	cpuProfile = flag.String("cpuprofile", "", "If set, write CPU profile to this file")
 	memProfile = flag.String("memprofile", "", "If set, write memory profile to this file")
+	maxMsgSize = flag.Int("max_msg_size_bytes", 1024*1024, "Max gRPC message size in bytes")
 )
 
 func main() {
@@ -193,13 +194,15 @@ func main() {
 		}
 		defer pprof.StopCPUProfile()
 	}
-
+	var options []grpc.ServerOption
+	options = append(options, grpc.MaxRecvMsgSize(*maxMsgSize))
 	m := serverutil.Main{
 		RPCEndpoint:      *rpcEndpoint,
 		HTTPEndpoint:     *httpEndpoint,
 		TLSCertFile:      *tlsCertFile,
 		TLSKeyFile:       *tlsKeyFile,
 		StatsPrefix:      "logsigner",
+		ExtraOptions:     options,
 		DBClose:          sp.Close,
 		Registry:         registry,
 		RegisterServerFn: func(s *grpc.Server, _ extension.Registry) error { return nil },

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -84,7 +84,7 @@ var (
 	// Profiling related flags.
 	cpuProfile = flag.String("cpuprofile", "", "If set, write CPU profile to this file")
 	memProfile = flag.String("memprofile", "", "If set, write memory profile to this file")
-	maxMsgSize = flag.Int("max_msg_size_bytes", 1024*1024, "Max gRPC message size in bytes")
+	maxMsgSize = flag.Int("max_msg_size_bytes", 4024*1024, "Max gRPC message size in bytes")
 )
 
 func main() {


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configurable maximum gRPC message size for Trillian log server components to prevent oversized requests.

Enhancements:
- Add a `max_msg_size_bytes` flag to log signer and log server for configuring the maximum gRPC receive message size
- Apply `grpc.MaxRecvMsgSize` option based on the new flag in both log signer and log server