### PR TITLE
cherry-pick: add optional gRPC max message size limit to trillian logserver and logsigner #3801

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Bump golangci-lint to v2.1.6
 * Fix leader resignation during a graceful shutdown by @osmman in https://github.com/google/trillian/pull/3790
+* Add optional gRPC message size limit via `--max_msg_size_bytes` flag by @fghanmi in https://github.com/google/trillian/pull/3801
 
 ## v1.7.2
 

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -76,6 +76,7 @@ var (
 	// Profiling related flags.
 	cpuProfile = flag.String("cpuprofile", "", "If set, write CPU profile to this file")
 	memProfile = flag.String("memprofile", "", "If set, write memory profile to this file")
+	maxMsgSize = flag.Int("max_msg_size_bytes", 0, "Optional max gRPC message size in bytes")
 )
 
 func main() {
@@ -107,6 +108,9 @@ func main() {
 		options = append(options, opts...)
 	}
 
+	if *maxMsgSize > 0 {
+		options = append(options, grpc.MaxRecvMsgSize(*maxMsgSize))
+	}
 	sp, err := storage.NewProvider(*storageSystem, mf)
 	if err != nil {
 		klog.Exitf("Failed to get storage provider: %v", err)

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -84,6 +84,7 @@ var (
 	// Profiling related flags.
 	cpuProfile = flag.String("cpuprofile", "", "If set, write CPU profile to this file")
 	memProfile = flag.String("memprofile", "", "If set, write memory profile to this file")
+	maxMsgSize = flag.Int("max_msg_size_bytes", 0, "Optional max gRPC message size in bytes")
 )
 
 func main() {
@@ -194,12 +195,17 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
+	var options []grpc.ServerOption
+	if *maxMsgSize > 0 {
+		options = append(options, grpc.MaxRecvMsgSize(*maxMsgSize))
+	}
 	m := serverutil.Main{
 		RPCEndpoint:      *rpcEndpoint,
 		HTTPEndpoint:     *httpEndpoint,
 		TLSCertFile:      *tlsCertFile,
 		TLSKeyFile:       *tlsKeyFile,
 		StatsPrefix:      "logsigner",
+		ExtraOptions:     options,
 		DBClose:          sp.Close,
 		Registry:         registry,
 		RegisterServerFn: func(s *grpc.Server, _ extension.Registry) error { return nil },


### PR DESCRIPTION
### Description
This change introduces a new optional flag --max_msg_size_bytes to both Trillian logsigner and logserver.

When set to a positive value, the flag enables a gRPC server-side limit on the size of incoming messages using grpc.MaxRecvMsgSize(). This provides a safeguard against resource exhaustion and potential denial-of-service (DoS) attacks caused by overly large client requests.

If the flag is unset or set to 0, no message size limit is enforced, preserving backward compatibility with existing deployments.

This change is non-breaking by design and is disabled by default.

---------

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly (including the [feature implementation matrix](docs/Feature_Implementation_Matrix.md)).

## Summary by Sourcery

Add a non‐breaking, opt‐in gRPC receive message size limit to the Trillian logserver and logsigner by introducing a new --max_msg_size_bytes flag that is disabled by default.

New Features:
- Introduce an optional --max_msg_size_bytes flag in Trillian logsigner and logserver to configure a gRPC server receive message size limit

Documentation:
- Update CHANGELOG to document the new max message size flag and its default behavior