### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for updatetree

### DIFF
--- a/Dockerfile.updatetree.rh
+++ b/Dockerfile.updatetree.rh
@@ -38,7 +38,8 @@ LABEL io.k8s.display-name="updatetree"
 LABEL io.openshift.tags="trillian updatetree trusted-artifact-signer"
 LABEL summary="Provides the trillian updatetree binary for updating merkel trees."
 LABEL com.redhat.component="updatetree"
-LABEL name="updatetree"
+LABEL name="rhtas/updatetree-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 COPY --from=build-env /opt/app-root/src/updatetree-darwin-amd64.gz /usr/local/bin/updatetree-darwin-amd64.gz
 COPY --from=build-env /opt/app-root/src/updatetree-windows-amd64.exe.gz /usr/local/bin/updatetree-windows-amd64.exe.gz


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
