### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for logsigner

### DIFF
--- a/Dockerfile.logsigner.rh
+++ b/Dockerfile.logsigner.rh
@@ -27,7 +27,8 @@ LABEL io.k8s.display-name="trillian_log_signer"
 LABEL io.openshift.tags="trillian-logsigner trusted-signer"
 LABEL summary="Provides the trillian logsigner binary for running trillian logsigner"
 LABEL com.redhat.component="trillian_log_signer"
-LABEL name="trillian_log_signer"
+LABEL name="rhtas/trillian-logsigner-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["/trillian_log_signer"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Add Name and correct CPE labels in the logsigner Dockerfile to support Clair VEX lookups

Bug Fixes:
- Fix CPE label value for logsigner Docker image

Enhancements:
- Add Name label to logsigner Docker image