### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for logserver

### DIFF
--- a/Dockerfile.logserver.rh
+++ b/Dockerfile.logserver.rh
@@ -27,7 +27,8 @@ LABEL io.k8s.display-name="trillian_log_server"
 LABEL io.openshift.tags="trillian-logserver trusted-signer"
 LABEL summary="Provides the trillian logserver binary for running trillian logserver"
 LABEL com.redhat.component="trillian_log_server"
-LABEL name="trillian_log_server"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
+LABEL name="rhtas/trillian-logserver-rhel9"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["/trillian_log_server"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Enhancements:
- Set the 'name' and 'cpe' labels in the logserver Dockerfile for vulnerability scanning