### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for createtree

### DIFF
--- a/Dockerfile.createtree.rh
+++ b/Dockerfile.createtree.rh
@@ -37,7 +37,8 @@ LABEL io.k8s.display-name="createtree"
 LABEL io.openshift.tags="trillian createtree trusted-artifact-signer"
 LABEL summary="Provides the trillian createtree binary for creating merkel trees."
 LABEL com.redhat.component="createtree"
-LABEL name="createtree"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
+LABEL name="rhtas/createtree-rhel9"
 
 COPY --from=build-env /opt/app-root/src/createtree-darwin-amd64.gz /usr/local/bin/createtree-darwin-amd64.gz
 COPY --from=build-env /opt/app-root/src/createtree-windows-amd64.exe.gz /usr/local/bin/createtree-windows-amd64.exe.gz


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Add name and CPE labels to the createtree image to enable Clair to locate the image in VEX statements

Enhancements:
- Add OCI image name label to the createtree Dockerfile
- Add CPE label to the createtree Dockerfile for Clair integration