### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for redis

### DIFF
--- a/Dockerfile.redis.rh
+++ b/Dockerfile.redis.rh
@@ -6,7 +6,8 @@ LABEL io.k8s.display-name="redis container image for Red Hat trusted artifact si
 LABEL io.openshift.tags="redis, Red Hat trusted artifact signer."
 LABEL summary="Runs redis in appendonly mode with enablement for external connections by default."
 LABEL com.redhat.component="redis"
-LABEL name="redis"
+LABEL name="rhtas/trillian-redis-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 USER 1001
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Add name and CPE labels to the Redis Docker image to support vulnerability lookup via Clair

Enhancements:
- Set the "name" label in the Redis Dockerfile for image identification
- Set the "cpe" label in the Redis Dockerfile for CPE-based vulnerability matching