### PR TITLE
build: rework cli-stack, move cross-compilation out of component images

### DIFF
--- a/.tekton/trillian-cli-stack-push.yaml
+++ b/.tekton/trillian-cli-stack-push.yaml
@@ -28,6 +28,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
     value: "false"
   - name: build-source-image

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -1,93 +1,97 @@
-FROM --platform=linux/amd64   quay.io/securesign/trillian-createtree@sha256:d05ca8ed661009c68e6964f8fdebde0b8ff5b8bfc63757c9d67f4e9d34caa449 AS createtree-amd64
-FROM --platform=linux/arm64   quay.io/securesign/trillian-createtree@sha256:170f40a5918f434f489abde2ee154030c9321053ab5ad0d8559d1de68874c84f AS createtree-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/trillian-createtree@sha256:caae5b258ff276cf75f305931131a7f26c44a562255ca7e7708e23c9ab79fc8a AS createtree-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/trillian-createtree@sha256:ca8c1450f7c59f84ebbb847fa6b69130e0027c92fd92d016eaf34acbc25fed67 AS createtree-s390x
+FROM registry.redhat.io/ubi9/go-toolset:9.7-1778604137@sha256:e06a6f4c85c3ca75f64127542449c9770fb885adfb592f987c576d268ac108de AS build-cross-platform
+ENV APP_ROOT=/opt/app-root \
+    GOPATH=/opt/app-root \
+    CGO_ENABLED=0 \
+    GOFLAGS="-buildvcs=false" \
+    GOEXPERIMENT=strictfipsruntime
 
-FROM --platform=linux/amd64   quay.io/securesign/trillian-updatetree@sha256:a8faaae4b7c8c0db529951e3d4937cabaf84a9569004c72cdbde900101632ff1 AS updatetree-amd64
-FROM --platform=linux/arm64   quay.io/securesign/trillian-updatetree@sha256:3dc96414da356bc7db6ab80aa5f1ea840bfec1a3f68fe1d85a56c2479c64ce27 AS updatetree-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/trillian-updatetree@sha256:6b559dc73c7f1e0bf5dc36700a16fe7261267987b28a1c385d1329a75d8f21ae AS updatetree-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/trillian-updatetree@sha256:2f255abb8d3d27452f83cadba766d2000ee48e6107904ce7495c51c986881ea1 AS updatetree-s390x
+WORKDIR $APP_ROOT/src
+ADD go.mod go.sum ./
+ADD ./ ./
+
+RUN go mod download && \
+    git config --global --add safe.directory /opt/app-root/src && \
+    make -f Build-clis.mak createtree-cross-platform && \
+    make -f Build-clis.mak updatetree-cross-platform
+
+FROM --platform=linux/amd64   quay.io/securesign/trillian-createtree@sha256:49ffea5617c003c5637d29a5a5eb6897039327270f46269a62152cabd61d3ce7 AS createtree-amd64
+FROM --platform=linux/arm64   quay.io/securesign/trillian-createtree@sha256:49ffea5617c003c5637d29a5a5eb6897039327270f46269a62152cabd61d3ce7 AS createtree-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/trillian-createtree@sha256:49ffea5617c003c5637d29a5a5eb6897039327270f46269a62152cabd61d3ce7 AS createtree-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/trillian-createtree@sha256:49ffea5617c003c5637d29a5a5eb6897039327270f46269a62152cabd61d3ce7 AS createtree-s390x
+
+FROM --platform=linux/amd64   quay.io/securesign/trillian-updatetree@sha256:f9ff07bab60d278a86e5b2d4ff66952a9ac218dadee500331e096558ffcb327f AS updatetree-amd64
+FROM --platform=linux/arm64   quay.io/securesign/trillian-updatetree@sha256:f9ff07bab60d278a86e5b2d4ff66952a9ac218dadee500331e096558ffcb327f AS updatetree-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/trillian-updatetree@sha256:f9ff07bab60d278a86e5b2d4ff66952a9ac218dadee500331e096558ffcb327f AS updatetree-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/trillian-updatetree@sha256:f9ff07bab60d278a86e5b2d4ff66952a9ac218dadee500331e096558ffcb327f AS updatetree-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.7-1778604137@sha256:e06a6f4c85c3ca75f64127542449c9770fb885adfb592f987c576d268ac108de AS packager
 USER root
 RUN mkdir -p /binaries
 
 # createtree: Native Linux binaries from each arch variant
-COPY --from=createtree-amd64 /usr/local/bin/createtree.gz /tmp/createtree.gz
-RUN gzip -d /tmp/createtree.gz && \
-    tar -czf /binaries/createtree_linux_amd64.tar.gz -C /tmp createtree && \
+COPY --from=createtree-amd64 /createtree /tmp/createtree
+RUN tar -czf /binaries/createtree_linux_amd64.tar.gz -C /tmp createtree && \
     rm /tmp/createtree
 
-COPY --from=createtree-arm64 /usr/local/bin/createtree.gz /tmp/createtree.gz
-RUN gzip -d /tmp/createtree.gz && \
-    tar -czf /binaries/createtree_linux_arm64.tar.gz -C /tmp createtree && \
+COPY --from=createtree-arm64 /createtree /tmp/createtree
+RUN tar -czf /binaries/createtree_linux_arm64.tar.gz -C /tmp createtree && \
     rm /tmp/createtree
 
-COPY --from=createtree-ppc64le /usr/local/bin/createtree.gz /tmp/createtree.gz
-RUN gzip -d /tmp/createtree.gz && \
-    tar -czf /binaries/createtree_linux_ppc64le.tar.gz -C /tmp createtree && \
+COPY --from=createtree-ppc64le /createtree /tmp/createtree
+RUN tar -czf /binaries/createtree_linux_ppc64le.tar.gz -C /tmp createtree && \
     rm /tmp/createtree
 
-COPY --from=createtree-s390x /usr/local/bin/createtree.gz /tmp/createtree.gz
-RUN gzip -d /tmp/createtree.gz && \
-    tar -czf /binaries/createtree_linux_s390x.tar.gz -C /tmp createtree && \
+COPY --from=createtree-s390x /createtree /tmp/createtree
+RUN tar -czf /binaries/createtree_linux_s390x.tar.gz -C /tmp createtree && \
     rm /tmp/createtree
 
 # createtree: Cross-compiled binaries
-COPY --from=createtree-amd64 /usr/local/bin/createtree-darwin-amd64.gz /tmp/createtree-darwin-amd64.gz
-RUN gzip -d /tmp/createtree-darwin-amd64.gz && \
-    tar -czf /binaries/createtree_darwin_amd64.tar.gz -C /tmp createtree-darwin-amd64 && \
-    rm /tmp/createtree-darwin-amd64
+COPY --from=build-cross-platform /opt/app-root/src/createtree-darwin-amd64 /tmp/createtree
+RUN tar -czf /binaries/createtree_darwin_amd64.tar.gz -C /tmp createtree && \
+    rm /tmp/createtree
 
-COPY --from=createtree-amd64 /usr/local/bin/createtree-darwin-arm64.gz /tmp/createtree-darwin-arm64.gz
-RUN gzip -d /tmp/createtree-darwin-arm64.gz && \
-    tar -czf /binaries/createtree_darwin_arm64.tar.gz -C /tmp createtree-darwin-arm64 && \
-    rm /tmp/createtree-darwin-arm64
+COPY --from=build-cross-platform /opt/app-root/src/createtree-darwin-arm64 /tmp/createtree
+RUN tar -czf /binaries/createtree_darwin_arm64.tar.gz -C /tmp createtree && \
+    rm /tmp/createtree
 
-COPY --from=createtree-amd64 /usr/local/bin/createtree-windows-amd64.exe.gz /tmp/createtree-windows-amd64.exe.gz
-RUN gzip -d /tmp/createtree-windows-amd64.exe.gz && \
-    tar -czf /binaries/createtree_windows_amd64.tar.gz -C /tmp createtree-windows-amd64.exe && \
-    rm /tmp/createtree-windows-amd64.exe
+COPY --from=build-cross-platform /opt/app-root/src/createtree-windows-amd64.exe /tmp/createtree.exe
+RUN tar -czf /binaries/createtree_windows_amd64.tar.gz -C /tmp createtree.exe && \
+    rm /tmp/createtree.exe
 
 # updatetree: Native Linux binaries from each arch variant
-COPY --from=updatetree-amd64 /usr/local/bin/updatetree.gz /tmp/updatetree.gz
-RUN gzip -d /tmp/updatetree.gz && \
-    tar -czf /binaries/updatetree_linux_amd64.tar.gz -C /tmp updatetree && \
+COPY --from=updatetree-amd64 /updatetree /tmp/updatetree
+RUN tar -czf /binaries/updatetree_linux_amd64.tar.gz -C /tmp updatetree && \
     rm /tmp/updatetree
 
-COPY --from=updatetree-arm64 /usr/local/bin/updatetree.gz /tmp/updatetree.gz
-RUN gzip -d /tmp/updatetree.gz && \
-    tar -czf /binaries/updatetree_linux_arm64.tar.gz -C /tmp updatetree && \
+COPY --from=updatetree-arm64 /updatetree /tmp/updatetree
+RUN tar -czf /binaries/updatetree_linux_arm64.tar.gz -C /tmp updatetree && \
     rm /tmp/updatetree
 
-COPY --from=updatetree-ppc64le /usr/local/bin/updatetree.gz /tmp/updatetree.gz
-RUN gzip -d /tmp/updatetree.gz && \
-    tar -czf /binaries/updatetree_linux_ppc64le.tar.gz -C /tmp updatetree && \
+COPY --from=updatetree-ppc64le /updatetree /tmp/updatetree
+RUN tar -czf /binaries/updatetree_linux_ppc64le.tar.gz -C /tmp updatetree && \
     rm /tmp/updatetree
 
-COPY --from=updatetree-s390x /usr/local/bin/updatetree.gz /tmp/updatetree.gz
-RUN gzip -d /tmp/updatetree.gz && \
-    tar -czf /binaries/updatetree_linux_s390x.tar.gz -C /tmp updatetree && \
+COPY --from=updatetree-s390x /updatetree /tmp/updatetree
+RUN tar -czf /binaries/updatetree_linux_s390x.tar.gz -C /tmp updatetree && \
     rm /tmp/updatetree
 
 # updatetree: Cross-compiled binaries
-COPY --from=updatetree-amd64 /usr/local/bin/updatetree-darwin-amd64.gz /tmp/updatetree-darwin-amd64.gz
-RUN gzip -d /tmp/updatetree-darwin-amd64.gz && \
-    tar -czf /binaries/updatetree_darwin_amd64.tar.gz -C /tmp updatetree-darwin-amd64 && \
-    rm /tmp/updatetree-darwin-amd64
+COPY --from=build-cross-platform /opt/app-root/src/updatetree-darwin-amd64 /tmp/updatetree
+RUN tar -czf /binaries/updatetree_darwin_amd64.tar.gz -C /tmp updatetree && \
+    rm /tmp/updatetree
 
-COPY --from=updatetree-amd64 /usr/local/bin/updatetree-darwin-arm64.gz /tmp/updatetree-darwin-arm64.gz
-RUN gzip -d /tmp/updatetree-darwin-arm64.gz && \
-    tar -czf /binaries/updatetree_darwin_arm64.tar.gz -C /tmp updatetree-darwin-arm64 && \
-    rm /tmp/updatetree-darwin-arm64
+COPY --from=build-cross-platform /opt/app-root/src/updatetree-darwin-arm64 /tmp/updatetree
+RUN tar -czf /binaries/updatetree_darwin_arm64.tar.gz -C /tmp updatetree && \
+    rm /tmp/updatetree
 
-COPY --from=updatetree-amd64 /usr/local/bin/updatetree-windows-amd64.exe.gz /tmp/updatetree-windows-amd64.exe.gz
-RUN gzip -d /tmp/updatetree-windows-amd64.exe.gz && \
-    tar -czf /binaries/updatetree_windows_amd64.tar.gz -C /tmp updatetree-windows-amd64.exe && \
-    rm /tmp/updatetree-windows-amd64.exe
+COPY --from=build-cross-platform /opt/app-root/src/updatetree-windows-amd64.exe /tmp/updatetree.exe
+RUN tar -czf /binaries/updatetree_windows_amd64.tar.gz -C /tmp updatetree.exe && \
+    rm /tmp/updatetree.exe
+
+RUN chmod -R a+rX /binaries
 
 # Final minimal image with all binaries
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be
+FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 
 LABEL description="Flat image containing createtree and updatetree CLI binaries for all platforms and architectures"
 LABEL io.k8s.description="Flat image containing createtree and updatetree CLI binaries for all platforms and architectures"
@@ -96,10 +100,9 @@ LABEL io.k8s.display-name="Trillian CLI stack image for Red Hat Trusted Artifact
 LABEL io.openshift.tags="trillian createtree updatetree trusted-artifact-signer cli-stack"
 LABEL summary="Provides all trillian CLI binaries (createtree, updatetree) as tar.gz archives for CDN distribution."
 LABEL com.redhat.component="trillian-cli-stack"
+LABEL name="rhtas/trillian-cli-stack"
 
 COPY --from=packager /binaries/ /binaries/
 COPY --from=createtree-amd64 /licenses/ /licenses/
-
-RUN chown -R root:0 /binaries && chmod -R g+r /binaries
 
 USER 65532:65532

--- a/Dockerfile.createtree.rh
+++ b/Dockerfile.createtree.rh
@@ -11,12 +11,9 @@ ADD ./ ./
 
 RUN go mod download && \
     git config --global --add safe.directory /opt/app-root/src && \
+    git update-index --assume-unchanged Dockerfile.createtree.rh && \
     go build -mod=mod -o createtree -trimpath ./cmd/createtree && \
-    gzip -k createtree && \
-    make -f Build-clis.mak createtree-cross-platform && \
-    gzip createtree-darwin-amd64 && \
-    gzip createtree-darwin-arm64 && \
-    gzip createtree-windows-amd64.exe
+    git update-index --no-assume-unchanged Dockerfile.createtree.rh
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be AS deploy
@@ -32,17 +29,9 @@ LABEL summary="Provides the trillian createtree binary for creating merkel trees
 LABEL com.redhat.component="createtree"
 LABEL name="rhtas/createtree-rhel9"
 
-COPY --from=build /opt/app-root/src/createtree /
-COPY --from=build /opt/app-root/src/createtree.gz /usr/local/bin/createtree.gz
-COPY --from=build /opt/app-root/src/createtree-darwin-amd64.gz /usr/local/bin/createtree-darwin-amd64.gz
-COPY --from=build /opt/app-root/src/createtree-windows-amd64.exe.gz /usr/local/bin/createtree-windows-amd64.exe.gz
-COPY --from=build /opt/app-root/src/createtree-darwin-arm64.gz /usr/local/bin/createtree-darwin-arm64.gz
+COPY --from=build /opt/app-root/src/createtree /createtree
 
-RUN chown root:0 createtree && chmod g+wx createtree && \
-    chown root:0 /usr/local/bin/createtree.gz && chmod g+wx /usr/local/bin/createtree.gz && \
-    chown root:0 /usr/local/bin/createtree-darwin-amd64.gz && chmod g+wx /usr/local/bin/createtree-darwin-amd64.gz && \
-    chown root:0 /usr/local/bin/createtree-darwin-arm64.gz && chmod g+wx /usr/local/bin/createtree-darwin-arm64.gz && \
-    chown root:0 /usr/local/bin/createtree-windows-amd64.exe.gz && chmod g+wx /usr/local/bin/createtree-windows-amd64.exe.gz
+RUN chown root:0 createtree && chmod g+wx createtree
 
 # Configure home directory
 ENV HOME=/home

--- a/Dockerfile.createtree.rh
+++ b/Dockerfile.createtree.rh
@@ -11,9 +11,7 @@ ADD ./ ./
 
 RUN go mod download && \
     git config --global --add safe.directory /opt/app-root/src && \
-    git update-index --assume-unchanged Dockerfile.createtree.rh && \
-    go build -mod=mod -o createtree -trimpath ./cmd/createtree && \
-    git update-index --no-assume-unchanged Dockerfile.createtree.rh
+    go build -mod=mod -o createtree -trimpath ./cmd/createtree
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be AS deploy

--- a/Dockerfile.updatetree.rh
+++ b/Dockerfile.updatetree.rh
@@ -11,9 +11,7 @@ ADD ./ ./
 
 RUN go mod download && \
     git config --global --add safe.directory /opt/app-root/src && \
-    git update-index --assume-unchanged Dockerfile.updatetree.rh && \
-    go build -mod=mod -o updatetree -trimpath ./cmd/updatetree && \
-    git update-index --no-assume-unchanged Dockerfile.updatetree.rh
+    go build -mod=mod -o updatetree -trimpath ./cmd/updatetree
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be AS deploy

--- a/Dockerfile.updatetree.rh
+++ b/Dockerfile.updatetree.rh
@@ -11,12 +11,9 @@ ADD ./ ./
 
 RUN go mod download && \
     git config --global --add safe.directory /opt/app-root/src && \
+    git update-index --assume-unchanged Dockerfile.updatetree.rh && \
     go build -mod=mod -o updatetree -trimpath ./cmd/updatetree && \
-    gzip -k updatetree && \
-    make -f Build-clis.mak updatetree-cross-platform && \
-    gzip updatetree-darwin-amd64 && \
-    gzip updatetree-darwin-arm64 && \
-    gzip updatetree-windows-amd64.exe
+    git update-index --no-assume-unchanged Dockerfile.updatetree.rh
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be AS deploy
@@ -32,17 +29,9 @@ LABEL summary="Provides the trillian updatetree binary for updating merkel trees
 LABEL com.redhat.component="updatetree"
 LABEL name="rhtas/updatetree-rhel9"
 
-COPY --from=build /opt/app-root/src/updatetree /
-COPY --from=build /opt/app-root/src/updatetree.gz /usr/local/bin/updatetree.gz
-COPY --from=build /opt/app-root/src/updatetree-darwin-amd64.gz /usr/local/bin/updatetree-darwin-amd64.gz
-COPY --from=build /opt/app-root/src/updatetree-windows-amd64.exe.gz /usr/local/bin/updatetree-windows-amd64.exe.gz
-COPY --from=build /opt/app-root/src/updatetree-darwin-arm64.gz /usr/local/bin/updatetree-darwin-arm64.gz
+COPY --from=build /opt/app-root/src/updatetree /updatetree
 
-RUN chown root:0 updatetree && chmod g+wx updatetree && \
-    chown root:0 /usr/local/bin/updatetree.gz && chmod g+wx /usr/local/bin/updatetree.gz && \
-    chown root:0 /usr/local/bin/updatetree-darwin-amd64.gz && chmod g+wx /usr/local/bin/updatetree-darwin-amd64.gz && \
-    chown root:0 /usr/local/bin/updatetree-darwin-arm64.gz && chmod g+wx /usr/local/bin/updatetree-darwin-arm64.gz && \
-    chown root:0 /usr/local/bin/updatetree-windows-amd64.exe.gz && chmod g+wx /usr/local/bin/updatetree-windows-amd64.exe.gz
+RUN chown root:0 updatetree && chmod g+wx updatetree
 
 ##Configure home directory
 ENV HOME=/home


### PR DESCRIPTION
## Summary
Backport of #708 to release-1.4 branch.

- **Component Dockerfiles** (`Dockerfile.createtree.rh`, `Dockerfile.updatetree.rh`): Remove cross-compilation (darwin/windows), all gzip steps. Output is now native Linux binary only.
- **CLI-stack Dockerfile** (`Dockerfile.cli-stack.rh`): Add `build-cross-platform` stage. Use single multi-arch manifest digest for all 4 arch FROM lines (createtree: `sha256:49ffea56...`, updatetree: `sha256:f9ff07ba...`). Copy native binaries directly. Switch final image to `ubi-micro:9.8`.
- **Tekton push pipeline**: Add `prefetch-input` for gomod.

Follows the pattern established in securesign/gitsign#357 and securesign/trillian#708.

> **Note**: Manifest digests will be auto-updated by Konflux nudge after component images rebuild.

## Test plan
- [ ] createtree component build succeeds on Konflux
- [ ] updatetree component build succeeds on Konflux
- [ ] CLI-stack build succeeds after component images rebuild
- [ ] Enterprise Contract passes