### PR TITLE
feat: FIPS 140-3 build hardening and cleanup

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: go mod edit -dropgodebug=fips140
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:

--- a/.github/workflows/test_crdb.yaml
+++ b/.github/workflows/test_crdb.yaml
@@ -25,8 +25,6 @@ jobs:
         check-latest: true
         cache: true
 
-    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-      run: go mod edit -dropgodebug=fips140
 
     - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
@@ -44,8 +42,6 @@ jobs:
         check-latest: true
         cache: true
 
-    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-      run: go mod edit -dropgodebug=fips140
 
     - name: Run tests
       run: go test -v ./storage/crdb/... ./quota/crdbqm/...
@@ -61,8 +57,6 @@ jobs:
         check-latest: true
         cache: true
 
-    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-      run: go mod edit -dropgodebug=fips140
 
     - name: Build before tests
       run: go mod download && go build ./...

--- a/.github/workflows/test_pgdb.yaml
+++ b/.github/workflows/test_pgdb.yaml
@@ -25,8 +25,6 @@ jobs:
         check-latest: true
         cache: true
 
-    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-      run: go mod edit -dropgodebug=fips140
 
     - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
@@ -59,8 +57,6 @@ jobs:
         check-latest: true
         cache: true
 
-    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-      run: go mod edit -dropgodebug=fips140
 
     - name: Build before tests
       run: go mod download && go build ./...

--- a/Build-clis.mak
+++ b/Build-clis.mak
@@ -4,16 +4,16 @@ createtree-cross-platform: createtree-darwin-arm64 createtree-darwin-amd64 creat
 # ---Darwin--- #
 .PHONY: createtree-darwin-amd64
 createtree-darwin-amd64:  ## Build for Darwin (macOS)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -o createtree-darwin-amd64 -trimpath ./cmd/createtree
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-darwin-amd64 -trimpath ./cmd/createtree
 
 .PHONY:	createtree-darwin-arm64
 createtree-darwin-arm64: ## Build for mac M1
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -o createtree-darwin-arm64 -trimpath ./cmd/createtree
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-darwin-arm64 -trimpath ./cmd/createtree
 
 # ---Windows--- #
 .PHONY: createtree-windows-amd64
 createtree-windows-amd64: ## Build for Windows
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -o createtree-windows-amd64.exe -trimpath ./cmd/createtree
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-windows-amd64.exe -trimpath ./cmd/createtree
 
 .PHONY:
 createtree-fips-cross-platform: createtree-fips-darwin-arm64 createtree-fips-darwin-amd64 createtree-fips-windows-amd64 ## Build all distributable FIPS (cross-platform) binaries
@@ -21,16 +21,16 @@ createtree-fips-cross-platform: createtree-fips-darwin-arm64 createtree-fips-dar
 # ---Darwin--- #
 .PHONY: createtree-fips-darwin-amd64
 createtree-fips-darwin-amd64:  ## Build FIPS for Darwin (macOS)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -tags fips,no_openssl -o createtree-fips-darwin-amd64 -trimpath ./cmd/createtree
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-fips-darwin-amd64 -trimpath ./cmd/createtree
 
 .PHONY:	createtree-fips-darwin-arm64
 createtree-fips-darwin-arm64: ## Build FIPS for mac M1
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -tags fips,no_openssl -o createtree-fips-darwin-arm64 -trimpath ./cmd/createtree
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-fips-darwin-arm64 -trimpath ./cmd/createtree
 
 # ---Windows--- #
 .PHONY: createtree-fips-windows-amd64
 createtree-fips-windows-amd64: ## Build FIPS for Windows
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags fips,no_openssl -o createtree-fips-windows-amd64.exe -trimpath ./cmd/createtree
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-fips-windows-amd64.exe -trimpath ./cmd/createtree
 
 .PHONY:
 updatetree-cross-platform: updatetree-darwin-arm64 updatetree-darwin-amd64 updatetree-windows-amd64 ## Build all distributable (cross-platform) binaries
@@ -38,16 +38,16 @@ updatetree-cross-platform: updatetree-darwin-arm64 updatetree-darwin-amd64 updat
 # ---Darwin--- #
 .PHONY:	updatetree-darwin-arm64
 updatetree-darwin-arm64: ## Build for mac M1
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -o updatetree-darwin-arm64 -trimpath ./cmd/updatetree
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-darwin-arm64 -trimpath ./cmd/updatetree
 
 .PHONY: updatetree-darwin-amd64
 updatetree-darwin-amd64:  ## Build for Darwin (macOS)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -o updatetree-darwin-amd64 -trimpath ./cmd/updatetree
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-darwin-amd64 -trimpath ./cmd/updatetree
 
 # ---Windows--- #
 .PHONY: updatetree-windows-amd64
 updatetree-windows-amd64: ## Build for Windows
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -o updatetree-windows-amd64.exe -trimpath ./cmd/updatetree
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-windows-amd64.exe -trimpath ./cmd/updatetree
 
 .PHONY:
 updatetree-fips-cross-platform: updatetree-fips-darwin-arm64 updatetree-fips-darwin-amd64 updatetree-fips-windows-amd64 ## Build all distributable FIPS (cross-platform) binaries
@@ -55,13 +55,13 @@ updatetree-fips-cross-platform: updatetree-fips-darwin-arm64 updatetree-fips-dar
 # ---Darwin--- #
 .PHONY:	updatetree-fips-darwin-arm64
 updatetree-fips-darwin-arm64: ## Build FIPS for mac M1
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -tags fips,no_openssl -o updatetree-fips-darwin-arm64 -trimpath ./cmd/updatetree
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-fips-darwin-arm64 -trimpath ./cmd/updatetree
 
 .PHONY: updatetree-fips-darwin-amd64
 updatetree-fips-darwin-amd64:  ## Build FIPS for Darwin (macOS)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -tags fips,no_openssl -o updatetree-fips-darwin-amd64 -trimpath ./cmd/updatetree
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-fips-darwin-amd64 -trimpath ./cmd/updatetree
 
 # ---Windows--- #
 .PHONY: updatetree-fips-windows-amd64
 updatetree-fips-windows-amd64: ## Build FIPS for Windows
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags fips,no_openssl -o updatetree-fips-windows-amd64.exe -trimpath ./cmd/updatetree
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-fips-windows-amd64.exe -trimpath ./cmd/updatetree

--- a/Build-clis.mak
+++ b/Build-clis.mak
@@ -16,23 +16,6 @@ createtree-windows-amd64: ## Build for Windows
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-windows-amd64.exe -trimpath ./cmd/createtree
 
 .PHONY:
-createtree-fips-cross-platform: createtree-fips-darwin-arm64 createtree-fips-darwin-amd64 createtree-fips-windows-amd64 ## Build all distributable FIPS (cross-platform) binaries
-
-# ---Darwin--- #
-.PHONY: createtree-fips-darwin-amd64
-createtree-fips-darwin-amd64:  ## Build FIPS for Darwin (macOS)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-fips-darwin-amd64 -trimpath ./cmd/createtree
-
-.PHONY:	createtree-fips-darwin-arm64
-createtree-fips-darwin-arm64: ## Build FIPS for mac M1
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-fips-darwin-arm64 -trimpath ./cmd/createtree
-
-# ---Windows--- #
-.PHONY: createtree-fips-windows-amd64
-createtree-fips-windows-amd64: ## Build FIPS for Windows
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree-fips-windows-amd64.exe -trimpath ./cmd/createtree
-
-.PHONY:
 updatetree-cross-platform: updatetree-darwin-arm64 updatetree-darwin-amd64 updatetree-windows-amd64 ## Build all distributable (cross-platform) binaries
 
 # ---Darwin--- #
@@ -48,20 +31,3 @@ updatetree-darwin-amd64:  ## Build for Darwin (macOS)
 .PHONY: updatetree-windows-amd64
 updatetree-windows-amd64: ## Build for Windows
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-windows-amd64.exe -trimpath ./cmd/updatetree
-
-.PHONY:
-updatetree-fips-cross-platform: updatetree-fips-darwin-arm64 updatetree-fips-darwin-amd64 updatetree-fips-windows-amd64 ## Build all distributable FIPS (cross-platform) binaries
-
-# ---Darwin--- #
-.PHONY:	updatetree-fips-darwin-arm64
-updatetree-fips-darwin-arm64: ## Build FIPS for mac M1
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-fips-darwin-arm64 -trimpath ./cmd/updatetree
-
-.PHONY: updatetree-fips-darwin-amd64
-updatetree-fips-darwin-amd64:  ## Build FIPS for Darwin (macOS)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-fips-darwin-amd64 -trimpath ./cmd/updatetree
-
-# ---Windows--- #
-.PHONY: updatetree-fips-windows-amd64
-updatetree-fips-windows-amd64: ## Build FIPS for Windows
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree-fips-windows-amd64.exe -trimpath ./cmd/updatetree

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -5,12 +5,14 @@ ENV APP_ROOT=/opt/app-root \
     GOFIPS140=v1.0.0 \
     GOFLAGS="-buildvcs=false"
 
+USER root
 WORKDIR $APP_ROOT/src
 ADD go.mod go.sum ./
 ADD ./ ./
 
 RUN go mod download && \
     git config --global --add safe.directory /opt/app-root/src && \
+    go mod edit -godebug=fips140=auto && \
     make -f Build-clis.mak createtree-cross-platform && \
     make -f Build-clis.mak updatetree-cross-platform
 

--- a/Dockerfile.createtree.rh
+++ b/Dockerfile.createtree.rh
@@ -5,12 +5,14 @@ ENV APP_ROOT=/opt/app-root \
     GOFIPS140=v1.0.0 \
     GOFLAGS="-buildvcs=false"
 
+USER root
 WORKDIR $APP_ROOT/src
 ADD go.mod go.sum ./
 ADD ./ ./
 
 RUN go mod download && \
     git config --global --add safe.directory /opt/app-root/src && \
+    go mod edit -godebug=fips140=auto && \
     go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree -trimpath ./cmd/createtree
 
 # Multi-Stage production build

--- a/Dockerfile.createtree.rh
+++ b/Dockerfile.createtree.rh
@@ -11,7 +11,7 @@ ADD ./ ./
 
 RUN go mod download && \
     git config --global --add safe.directory /opt/app-root/src && \
-    go build -mod=mod -tags no_openssl -o createtree -trimpath ./cmd/createtree
+    go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o createtree -trimpath ./cmd/createtree
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23 AS deploy

--- a/Dockerfile.logserver.rh
+++ b/Dockerfile.logserver.rh
@@ -4,6 +4,7 @@ ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=0
 ENV GOFIPS140=v1.0.0
 
+USER root
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/
 RUN go mod download
@@ -12,7 +13,8 @@ RUN git config --global --add safe.directory /opt/app-root/src
 # Add source code
 ADD ./ $APP_ROOT/src/
 
-RUN go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -v ./cmd/trillian_log_server
+RUN go mod edit -godebug=fips140=auto && \
+    go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -v ./cmd/trillian_log_server
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23 AS deploy

--- a/Dockerfile.logserver.rh
+++ b/Dockerfile.logserver.rh
@@ -12,7 +12,7 @@ RUN git config --global --add safe.directory /opt/app-root/src
 # Add source code
 ADD ./ $APP_ROOT/src/
 
-RUN go build -mod=mod -tags no_openssl -v ./cmd/trillian_log_server
+RUN go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -v ./cmd/trillian_log_server
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23 AS deploy

--- a/Dockerfile.logsigner.rh
+++ b/Dockerfile.logsigner.rh
@@ -4,6 +4,7 @@ ENV GOPATH=$APP_ROOT
 ENV CGO_ENABLED=0
 ENV GOFIPS140=v1.0.0
 
+USER root
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/
 RUN go mod download
@@ -12,7 +13,8 @@ RUN git config --global --add safe.directory /opt/app-root/src
 # Add source code
 ADD ./ $APP_ROOT/src/
 
-RUN go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -v ./cmd/trillian_log_signer
+RUN go mod edit -godebug=fips140=auto && \
+    go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -v ./cmd/trillian_log_signer
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23 AS deploy

--- a/Dockerfile.logsigner.rh
+++ b/Dockerfile.logsigner.rh
@@ -12,7 +12,7 @@ RUN git config --global --add safe.directory /opt/app-root/src
 # Add source code
 ADD ./ $APP_ROOT/src/
 
-RUN go build -mod=mod -tags no_openssl -v ./cmd/trillian_log_signer
+RUN go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -v ./cmd/trillian_log_signer
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23 AS deploy

--- a/Dockerfile.updatetree.rh
+++ b/Dockerfile.updatetree.rh
@@ -11,7 +11,7 @@ ADD ./ ./
 
 RUN go mod download && \
     git config --global --add safe.directory /opt/app-root/src && \
-    go build -mod=mod -tags no_openssl -o updatetree -trimpath ./cmd/updatetree
+    go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree -trimpath ./cmd/updatetree
 
 # Multi-Stage production build
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23 AS deploy

--- a/Dockerfile.updatetree.rh
+++ b/Dockerfile.updatetree.rh
@@ -5,12 +5,14 @@ ENV APP_ROOT=/opt/app-root \
     GOFIPS140=v1.0.0 \
     GOFLAGS="-buildvcs=false"
 
+USER root
 WORKDIR $APP_ROOT/src
 ADD go.mod go.sum ./
 ADD ./ ./
 
 RUN go mod download && \
     git config --global --add safe.directory /opt/app-root/src && \
+    go mod edit -godebug=fips140=auto && \
     go build -mod=mod -tags 'postgresql,mysql,k8s,no_openssl' -o updatetree -trimpath ./cmd/updatetree
 
 # Multi-Stage production build

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/google/trillian
 
 go 1.26.0
 
-godebug fips140=auto
-
 require (
 	bitbucket.org/creachadair/shell v0.0.9
 	cloud.google.com/go/spanner v1.89.0


### PR DESCRIPTION
## Summary

- Add explicit build tags (`postgresql,mysql,k8s,no_openssl`) to all `.rh` Dockerfiles
  and cross-platform Makefile targets to exclude unsupported backends (Cloud Spanner,
  CockroachDB, etcd) and their non-approved crypto dependencies from compiled binaries
- Move `godebug fips140=auto` from `go.mod` to build-time injection
  (`go mod edit -godebug=fips140=auto`) in `.rh` Dockerfiles, eliminating the need for
  `dropgodebug` workarounds in CI workflows
- Remove vestigial `-fips-` Makefile targets that are unnecessary with Go 1.26 native
  FIPS (`GOFIPS140=v1.0.0` + `fips140=auto` embeds the FIPS module in every build)