### PR TITLE
Update release-version to 1.5.0

### DIFF
--- a/.tekton/createtree-pull-request.yaml
+++ b/.tekton/createtree-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/createtree-push.yaml
+++ b/.tekton/createtree-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/database-pull-request.yaml
+++ b/.tekton/database-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.database.rh
   - name: git-url

--- a/.tekton/database-push.yaml
+++ b/.tekton/database-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.database.rh
   - name: git-url

--- a/.tekton/logserver-pull-request.yaml
+++ b/.tekton/logserver-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.logserver.rh
   - name: git-url

--- a/.tekton/logserver-push.yaml
+++ b/.tekton/logserver-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.logserver.rh
   - name: git-url

--- a/.tekton/logsigner-pull-request.yaml
+++ b/.tekton/logsigner-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.logsigner.rh
   - name: git-url

--- a/.tekton/logsigner-push.yaml
+++ b/.tekton/logsigner-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.logsigner.rh
   - name: git-url

--- a/.tekton/redis-pull-request.yaml
+++ b/.tekton/redis-pull-request.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.redis.rh
   - name: git-url

--- a/.tekton/redis-push.yaml
+++ b/.tekton/redis-push.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.redis.rh
   - name: git-url

--- a/.tekton/trillian-cli-stack-pull-request.yaml
+++ b/.tekton/trillian-cli-stack-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: git-url

--- a/.tekton/trillian-cli-stack-push.yaml
+++ b/.tekton/trillian-cli-stack-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
   - name: git-url

--- a/.tekton/updatetree-pull-request.yaml
+++ b/.tekton/updatetree-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/updatetree-push.yaml
+++ b/.tekton/updatetree-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   - name: git-url
     value: '{{source_url}}'
   - name: revision


### PR DESCRIPTION
## Summary
- Update `release-version` parameter from `1.4.0` to `1.5.0` in all `.tekton` pipeline definitions

## Test plan
- [ ] Verify Tekton pipeline definitions are valid YAML
- [ ] Confirm `release-version` is set to `1.5.0` in all pipeline files

🤖 Generated with [Claude Code](https://claude.com/claude-code)